### PR TITLE
Use fill property with svg element directly instead of inline styles.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,14 +24,16 @@ export const allStaticIcons = Object.keys(staticIcons);
 export interface SuomifiIconInterface {
   icon: IconKeys | StaticIconKeys;
   color?: string;
+  fill?: string;
   className?: string;
 }
 
 export class SuomifiIcon extends React.Component<SuomifiIconInterface> {
   render() {
-    const { icon, color, ...passProps } = this.props;
-    const style = !(icon in staticIcons) && !!color ? { fill: color } : {};
+    const { icon, color, fill: origFill, ...passProps } = this.props;
+    const fill = !!origFill ? origFill : color;
+    const fillProp = !(icon in staticIcons) && !!fill ? { fill: fill } : {};
     const Svg = getIcon(icon) as SvgrComponent;
-    return <Svg {...passProps} style={style} />;
+    return <Svg {...passProps} {...fillProp} />;
   }
 }


### PR DESCRIPTION
This PR removes inline style attribute used to apply color fills for SVG-elements.

- Fill attribute is now used directly instead of setting the fill color using style.
- API for the component now supports both fill and color-attributes.
- Fill attribute takes precedence over color.

Strict Content-Security-Policy settings should now be better supported.

Resolves and closes #15 