### PR TITLE
Pass unsupported props from suomifiIcon to svg

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,5 +1,5 @@
 interface SvgrComponent
-  extends React.FunctionComponent<React.SVGAttributes<SVGElement>> {}
+  extends React.FunctionComponent<React.SVGProps<SVGElement>> {}
 
 declare module '*.svg' {
   const value: SvgrComponent;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,7 @@ export interface SuomifiIconInterface {
   color?: string;
   fill?: string;
   className?: string;
-  //allow passing unsupported props to Svg
+  // Allow passing unsupported custom props to SVG without providing an API
   [key: string]: any;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,6 +26,8 @@ export interface SuomifiIconInterface {
   color?: string;
   fill?: string;
   className?: string;
+  //allow passing unsupported props to Svg
+  [key: string]: any;
 }
 
 export class SuomifiIcon extends React.Component<SuomifiIconInterface> {


### PR DESCRIPTION
## Description

This PR adds support for passing through unsupported props for suomifiIcon. Also the internal SVG component now supports more extensive API by for example allowing the use of ref.

Relates to issue #15

## Motivation and Context

Also props that suomifiIcon does not process are passed through to the svg. For example style and aria-labels. This allows more flexible use of suomifiIcon and does not restrict the use of props to only the ones necessary for the component to be functional.

The current API is extended by allowing any prop to be passed without explicitly defining supported props. This solution allows more flexible use of the component without polluting the API with general props and exposing those to e.g. editor autocomplete.

Closes #17 

## How Has This Been Tested?

Tested with CRA and Verdaccio using props that the suomifiIcon only passes through.
