### PR TITLE
[Feature] Doctype and basic icon additions

### DIFF
--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,8 +1,15 @@
-import arrowDown from './icons/icon-arrow-down.svg';
 import arrowUp from './icons/icon-arrow-up.svg';
+import arrowRight from './icons/icon-arrow-right.svg';
+import arrowDown from './icons/icon-arrow-down.svg';
+import arrowLeft from './icons/icon-arrow-left.svg';
+import arrowheadDown from './icons/icon-arrowhead-down.svg';
+import arrowheadUp from './icons/icon-arrowhead-up.svg';
 import attachment from './icons/icon-attachment.svg';
 import authorise from './icons/icon-authorise.svg';
+import bicycle from './icons/icon-bicycle.svg';
+import bus from './icons/icon-bus.svg';
 import calendar from './icons/icon-calendar.svg';
+import car from './icons/icon-car.svg';
 import chatHeart from './icons/icon-chat-heart.svg';
 import chatQuestion from './icons/icon-chat-question.svg';
 import checkFilled from './icons/icon-check-filled.svg';
@@ -11,15 +18,30 @@ import chevronUp from './icons/icon-chevron-up.svg';
 import chevronRight from './icons/icon-chevron-right.svg';
 import chevronDown from './icons/icon-chevron-down.svg';
 import chevronLeft from './icons/icon-chevron-left.svg';
+import chevronCircleUp from './icons/icon-chevron-circle-up.svg';
+import chevronCircleRight from './icons/icon-chevron-circle-right.svg';
+import chevronCircleDown from './icons/icon-chevron-circle-down.svg';
+import chevronCircleLeft from './icons/icon-chevron-circle-left.svg';
 import close from './icons/icon-close.svg';
+import compare from './icons/icon-compare.svg';
+import compareRemove from './icons/icon-compare-remove.svg';
+import controlPrevious from './icons/icon-control-previous.svg';
+import controlPlay from './icons/icon-control-play.svg';
+import controlNext from './icons/icon-control-next.svg';
 import copy from './icons/icon-copy.svg';
+import disabled from './icons/icon-disabled.svg';
 import done from './icons/icon-done.svg';
+import download from './icons/icon-download.svg';
+import edit from './icons/icon-edit.svg';
 import errorFilled from './icons/icon-error-filled.svg';
 import error from './icons/icon-error.svg';
+import expandableMinus from './icons/icon-expandable-minus.svg';
+import expandablePlus from './icons/icon-expandable-plus.svg';
 import heartFilled from './icons/icon-heart-filled.svg';
 import heart from './icons/icon-heart.svg';
 import helpFilled from './icons/icon-help-filled.svg';
 import help from './icons/icon-help.svg';
+import history from './icons/icon-history.svg';
 import infoFilled from './icons/icon-info-filled.svg';
 import info from './icons/icon-info.svg';
 import internet from './icons/icon-internet.svg';
@@ -38,27 +60,39 @@ import map from './icons/icon-map.svg';
 import menu from './icons/icon-menu.svg';
 import message from './icons/icon-message.svg';
 import minus from './icons/icon-minus.svg';
+import pedestrian from './icons/icon-pedestrian.svg';
+import pin from './icons/icon-pin.svg';
 import phone from './icons/icon-phone.svg';
 import plus from './icons/icon-plus.svg';
+import preview from './icons/icon-preview.svg';
 import print from './icons/icon-print.svg';
 import radioButtonOn from './icons/icon-radio-button-on.svg';
 import refresh from './icons/icon-refresh.svg';
 import registers from './icons/icon-registers.svg';
 import remove from './icons/icon-remove.svg';
+import reply from './icons/icon-reply.svg';
 import save from './icons/icon-save.svg';
 import search from './icons/icon-search.svg';
 import settings from './icons/icon-settings.svg';
+import signLanguageContent from './icons/icon-sign-language-content.svg';
 import swapRounded from './icons/icon-swap-rounded.svg';
 import swapVertical from './icons/icon-swap-vertical.svg';
 
 export type IconKeys = keyof typeof icons;
 
 export const icons = {
-  arrowDown,
   arrowUp,
+  arrowRight,
+  arrowDown,
+  arrowLeft,
+  arrowheadDown,
+  arrowheadUp,
   attachment,
   authorise,
+  bicycle,
+  bus,
   calendar,
+  car,
   chatHeart,
   chatQuestion,
   checkFilled,
@@ -67,15 +101,30 @@ export const icons = {
   chevronRight,
   chevronDown,
   chevronLeft,
+  chevronCircleUp,
+  chevronCircleRight,
+  chevronCircleDown,
+  chevronCircleLeft,
   close,
+  compare,
+  compareRemove,
+  controlPrevious,
+  controlPlay,
+  controlNext,
   copy,
+  disabled,
   done,
+  download,
+  edit,
   errorFilled,
   error,
+  expandableMinus,
+  expandablePlus,
   heartFilled,
   heart,
   helpFilled,
   help,
+  history,
   infoFilled,
   info,
   internet,
@@ -94,16 +143,21 @@ export const icons = {
   menu,
   message,
   minus,
+  pedestrian,
+  pin,
   phone,
   plus,
+  preview,
   print,
   radioButtonOn,
   refresh,
   registers,
   remove,
+  reply,
   save,
   search,
   settings,
+  signLanguageContent,
   swapRounded,
   swapVertical
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { IconKeys, icons } from './icons';
-import { StaticIconKeys, staticIcons } from './staticIcons';
+import {
+  StaticIconKeys,
+  staticIcons,
+  DoctypeIconKeys,
+  doctypeIcons
+} from './staticIcons';
 export { IconKeys } from './icons';
-export { StaticIconKeys } from './staticIcons';
+export { StaticIconKeys, DoctypeIconKeys } from './staticIcons';
 
 const fallbackIcon = 'login';
 
@@ -10,19 +15,22 @@ function objValue<T, K extends keyof T>(obj: T, key: K) {
   return obj[key];
 }
 
-const getIcon = (icon: IconKeys | StaticIconKeys) => {
+const getIcon = (icon: IconKeys | StaticIconKeys | DoctypeIconKeys) => {
   const suomifiIcon =
     icon in icons
       ? objValue(icons, icon as IconKeys)
-      : objValue(staticIcons, icon as StaticIconKeys);
+      : icon in staticIcons
+      ? objValue(staticIcons, icon as StaticIconKeys)
+      : objValue(doctypeIcons, icon as DoctypeIconKeys);
   return !!suomifiIcon ? suomifiIcon : objValue(icons, fallbackIcon);
 };
 
 export const allIcons = Object.keys(icons);
 export const allStaticIcons = Object.keys(staticIcons);
+export const allDoctypeIcons = Object.keys(doctypeIcons);
 
 export interface SuomifiIconInterface {
-  icon: IconKeys | StaticIconKeys;
+  icon: IconKeys | StaticIconKeys | DoctypeIconKeys;
   color?: string;
   fill?: string;
   className?: string;
@@ -34,7 +42,10 @@ export class SuomifiIcon extends React.Component<SuomifiIconInterface> {
   render() {
     const { icon, color, fill: origFill, ...passProps } = this.props;
     const fill = !!origFill ? origFill : color;
-    const fillProp = !(icon in staticIcons) && !!fill ? { fill: fill } : {};
+    const fillProp =
+      !(icon in staticIcons || icon in doctypeIcons) && !!fill
+        ? { fill: fill }
+        : {};
     const Svg = getIcon(icon) as SvgrComponent;
     return <Svg {...passProps} {...fillProp} />;
   }

--- a/src/staticIcons.ts
+++ b/src/staticIcons.ts
@@ -80,6 +80,13 @@ import staticIllustrationWomanButtons from './staticIcons/icon-illustration-woma
 import staticIllustrationWomanNecklace from './staticIcons/icon-illustration-woman-necklace.svg';
 import toggle from './staticIcons/icon-toggle.svg';
 
+import doc from './staticIcons/icon-doc.svg';
+import generic from './staticIcons/icon-generic.svg';
+import pdf from './staticIcons/icon-pdf.svg';
+import ppt from './staticIcons/icon-ppt.svg';
+import xls from './staticIcons/icon-xls.svg';
+import xml from './staticIcons/icon-xml.svg';
+
 export type StaticIconKeys = keyof typeof staticIcons;
 
 export const staticIcons = {
@@ -164,4 +171,15 @@ export const staticIcons = {
   staticIllustrationWomanButtons,
   staticIllustrationWomanNecklace,
   toggle
+};
+
+export type DoctypeIconKeys = keyof typeof staticIcons;
+
+export const doctypeIcons = {
+  doc,
+  generic,
+  pdf,
+  ppt,
+  xls,
+  xml
 };

--- a/src/staticIcons.ts
+++ b/src/staticIcons.ts
@@ -173,7 +173,7 @@ export const staticIcons = {
   toggle
 };
 
-export type DoctypeIconKeys = keyof typeof staticIcons;
+export type DoctypeIconKeys = keyof typeof doctypeIcons;
 
 export const doctypeIcons = {
   doc,


### PR DESCRIPTION
## Description

This PR adds new basic icons and doctype icons and related typings.

## Motivation and Context

Icons present in design system style guide should be available for implementation as well.

## How Has This Been Tested?

Tested with Suomi.fi Design System Site locally using Verdaccio and the icon component exported by suomifi-icons (instead of the one from ui-components that is used normally).
