### PR TITLE
[Bugfix] Replace SvgrComponent type with any

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,7 +1,4 @@
-interface SvgrComponent
-  extends React.FunctionComponent<React.SVGProps<SVGElement>> {}
-
 declare module '*.svg' {
-  const value: SvgrComponent;
+  const value: any;
   export default value;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,7 +46,7 @@ export class SuomifiIcon extends React.Component<SuomifiIconInterface> {
       !(icon in staticIcons || icon in doctypeIcons) && !!fill
         ? { fill: fill }
         : {};
-    const Svg = getIcon(icon) as SvgrComponent;
+    const Svg = getIcon(icon) as any;
     return <Svg {...passProps} {...fillProp} />;
   }
 }


### PR DESCRIPTION
A temporary fix for a typing issue where the custom 'SvgrComponent' type couldn't be included in the build for some reason, which resulted in typing errors when using the library.

The file structure is intact, but the type is replaced by type 'any' for now. When this PR gets approved I'll create an issue for fixing this properly in the future.

The solution was tested with a CRA as well as an SSR test project.