### PR TITLE
Raise version to 0.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-icons",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Suomi.fi icons-library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
A temporary fix for a typing issue where the custom 'SvgrComponent' type couldn't be included in the build for some reason, which resulted in typing errors when using the library.