### PR TITLE
Publish 0.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-icons",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Suomi.fi icons-library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Raise version to 0.0.14. Version includes a switch from discontinued awesome typescript loader to ts-loader.