### PR TITLE
[Fix] Updated the required peerDependencies to lower version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "webpack-cli": "3.3.11"
   },
   "peerDependencies": {
-    "react": "16.6.3",
-    "react-dom": "16.6.3"
+    "react": ">=16.3",
+    "react-dom": ">=16.3"
   },
   "scripts": {
     "build": "webpack"


### PR DESCRIPTION
## Details

- Library had **peerDependencies** that was at unneeded high version. Lowered the required level of those to be in line with **suomifi-ui-components**.
- It was also specified to be exact version, now it is more allowing.

## Testing

Tested locally to use the updated build in **suomifi-ui-components**.

## Other
- branch name is incorrectly mentioning devDep