### PR TITLE
[Release] Increase version number to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-icons",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Suomi.fi icons-library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Increase version number to 3.0.0
* **Breaking change**: Change illustrative icons svg class names. Fill and stroke are now combined and base color class name is added.
* **Breaking change**: svg’s in the repository no longer contain class names.