### PR TITLE
[Feature] Separate class names for highlight and base

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,14 +46,24 @@ module.exports = (env) => ({
                         params: {
                           rules: [
                             {
-                              attribute: 'fill|stroke',
+                              attribute: 'fill',
                               value: '#A5ADB1',
-                              className: 'fi-icon-illustrative-base'
+                              className: 'fi-icon-illustrative-base-fill'
                             },
                             {
-                              attribute: 'fill|stroke',
+                              attribute: 'stroke',
+                              value: '#A5ADB1',
+                              className: 'fi-icon-illustrative-base-stroke'
+                            },
+                            {
+                              attribute: 'fill',
                               value: '#E97025',
-                              className: 'fi-icon-illustrative-highlight'
+                              className: 'fi-icon-illustrative-highlight-fill'
+                            },
+                            {
+                              attribute: 'stroke',
+                              value: '#E97025',
+                              className: 'fi-icon-illustrative-highlight-stroke'
                             }
                           ]
                         }


### PR DESCRIPTION
## Description

- Separating class names for highlight and base, so that both have `-fill` and `-stroke`.
- Highlight colour is the one that is by default the orange, `#E97025`, in the icons. 
- Base colour is they grey, `#A5ADB1`, in the icons.
- Based on the icon, it might have used fill or/and stroke.

## Details
Available class names are these:
```
fi-icon-illustrative-base-fill
fi-icon-illustrative-base-stroke
fi-icon-illustrative-highlight-fill
fi-icon-illustrative-highlight-stroke
```

Which will then enable users of the icon library to use it like this:

```css
.fi-icon-illustrative-highlight-fill {
  fill: #dddddd;
}
.fi-icon-illustrative-highlight-stroke {
  stroke: #ffffff;
}

.fi-icon-illustrative-base-fill {
  fill: #fff000;
}

.fi-icon-illustrative-base-stroke {
  stroke: #cccccc;
}
```

## Tested

Tested in CRA-TS project.

```tsx
import { SuomifiStaticIcon } from "suomifi-icons";
// ...
<SuomifiStaticIcon icon="train" width="80px" height="80px" />
<SuomifiStaticIcon
        className="custom-icon"
        icon="train"
        width="80px"
        height="80px"
      />
// ...
```

```css
.custom-icon .fi-icon-illustrative-highlight-fill {
  fill: #2a6ebb;
}
.custom-icon .fi-icon-illustrative-highlight-stroke {
  stroke: #86499c;
}

.custom-icon .fi-icon-illustrative-base-fill {
  fill: #faaf00;
}

.custom-icon .fi-icon-illustrative-base-stroke {
  stroke: #1a99c7;
}
```

Screenshot
<img width="329" alt="image" src="https://user-images.githubusercontent.com/53757053/123228481-2267fa80-d4de-11eb-9b68-38e92befdee2.png">


## Release notes

**Breaking change**: Change illustrative icons svg class names. Fill and stroke are now separated and base color class name is added.