### PR TITLE
[Release] v6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-icons",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Suomi.fi icons-library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR raises the version number in anticipation of the 6.0.0 release which features the updated `baseIcon` fill color to match changed designs.