### PR TITLE
[Feature] Add loading spinner icon to componentIcons

### DIFF
--- a/src/componentIcons.ts
+++ b/src/componentIcons.ts
@@ -1,7 +1,7 @@
 import radioButton from './componentIcons/icon-radio-button.svg';
 import radioButtonLarge from './componentIcons/icon-radio-button-large.svg';
 import toggle from './componentIcons/icon-toggle.svg';
-import loadingSpinner from './componentIcons/icon-loading-spinner.svg';
+import preloader from './componentIcons/icon-preloader.svg';
 
 export type ComponentIconKeys = keyof typeof componentIcons;
 
@@ -9,5 +9,5 @@ export const componentIcons = {
   radioButton,
   radioButtonLarge,
   toggle,
-  loadingSpinner
+  preloader
 };

--- a/src/componentIcons.ts
+++ b/src/componentIcons.ts
@@ -1,11 +1,13 @@
 import radioButton from './componentIcons/icon-radio-button.svg';
 import radioButtonLarge from './componentIcons/icon-radio-button-large.svg';
 import toggle from './componentIcons/icon-toggle.svg';
+import loadingSpinner from './componentIcons/icon-loading-spinner.svg';
 
 export type ComponentIconKeys = keyof typeof componentIcons;
 
 export const componentIcons = {
   radioButton,
   radioButtonLarge,
-  toggle
+  toggle,
+  loadingSpinner
 };

--- a/src/componentIcons/icon-loading-spinner.svg
+++ b/src/componentIcons/icon-loading-spinner.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg aria-hidden="true" viewBox="0 0 40 40" version="1.1">
+<svg viewBox="0 0 40 40" version="1.1">
     <title>Loading Spinner</title>
     <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
         <path

--- a/src/componentIcons/icon-loading-spinner.svg
+++ b/src/componentIcons/icon-loading-spinner.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg aria-hidden="true" viewBox="0 0 40 40" version="1.1">
+    <title>Loading Spinner</title>
+    <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+        <path
+            d="M20,0 L20,3 C10.6111593,3 3,10.6111593 3,20 C3,29.3888407 10.6111593,37 20,37 C29.280923,37 36.824796,29.5628044 36.9969921,20.3230397 L37,20 L40,20 C40,31.045695 31.045695,40 20,40 C8.954305,40 0,31.045695 0,20 C0,9.06936433 8.76872859,0.186774951 19.6555106,0.00290705581 L20,0 Z"
+            fill="#00347A"
+            fillRule="nonzero"
+        />
+    </g>
+</svg>

--- a/src/componentIcons/icon-preloader.svg
+++ b/src/componentIcons/icon-preloader.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="0 0 40 40" version="1.1">
-    <title>Loading Spinner</title>
+    <title>Preloader</title>
     <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
         <path
             d="M20,0 L20,3 C10.6111593,3 3,10.6111593 3,20 C3,29.3888407 10.6111593,37 20,37 C29.280923,37 36.824796,29.5628044 36.9969921,20.3230397 L37,20 L40,20 C40,31.045695 31.045695,40 20,40 C8.954305,40 0,31.045695 0,20 C0,9.06936433 8.76872859,0.186774951 19.6555106,0.00290705581 L20,0 Z"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -110,7 +110,12 @@ module.exports = (env) => ({
                               attribute: 'stroke',
                               value: '#E97025',
                               className: 'fi-icon-component-highlight-stroke'
-                            }
+                            },
+                            {
+                              attribute: 'fill',
+                              value: '#00347A',
+                              className: 'fi-icon-component-brand-fill'
+                            },
                           ]
                         }
                       }


### PR DESCRIPTION
This PR adds a loading spinner (preloader) icon to componentIcons. The icon is exported with the name `preloader`.

Also added a new classname to Webpack build conf for baseBrand filled SVGs: `fi-icon-component-brand-fill`