### PR TITLE
[Feature] Add action menu icon to baseIcons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-icons",
-  "version": "6.4.0",
+  "version": "6.3.0",
   "description": "Suomi.fi icons-library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-icons",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "Suomi.fi icons-library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/baseIcons.ts
+++ b/src/baseIcons.ts
@@ -73,6 +73,7 @@ import map from './baseIcons/icon-map.svg';
 import menu from './baseIcons/icon-menu.svg';
 import message from './baseIcons/icon-message.svg';
 import minus from './baseIcons/icon-minus.svg';
+import optionsVertical from './baseIcons/icon-options-vertical.svg';
 import peek from './baseIcons/icon-peek.svg';
 import pin from './baseIcons/icon-pin.svg';
 import phone from './baseIcons/icon-phone.svg';
@@ -178,6 +179,7 @@ export const baseIcons = {
   menu,
   message,
   minus,
+  optionsVertical,
   peek,
   pin,
   phone,

--- a/src/baseIcons/icon-options-vertical.svg
+++ b/src/baseIcons/icon-options-vertical.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Icons/Basic icons/options-vertical</title>
+    <g id="Icons/Basic-icons/options-vertical" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M12,6 C10.346,6 9,4.654 9,3 C9,1.346 10.346,0 12,0 C13.654,0 15,1.346 15,3 C15,4.654 13.654,6 12,6 M12,15 C10.346,15 9,13.654 9,12 C9,10.346 10.346,9 12,9 C13.654,9 15,10.346 15,12 C15,13.654 13.654,15 12,15 M12,24 C10.346,24 9,22.654 9,21 C9,19.346 10.346,18 12,18 C13.654,18 15,19.346 15,21 C15,22.654 13.654,24 12,24" id="Combined-Shape" fill="#222222"></path>
+    </g>
+</svg>

--- a/src/baseIcons/icon-options-vertical.svg
+++ b/src/baseIcons/icon-options-vertical.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>Icons/Basic icons/options-vertical</title>
     <g id="Icons/Basic-icons/options-vertical" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <path d="M12,6 C10.346,6 9,4.654 9,3 C9,1.346 10.346,0 12,0 C13.654,0 15,1.346 15,3 C15,4.654 13.654,6 12,6 M12,15 C10.346,15 9,13.654 9,12 C9,10.346 10.346,9 12,9 C13.654,9 15,10.346 15,12 C15,13.654 13.654,15 12,15 M12,24 C10.346,24 9,22.654 9,21 C9,19.346 10.346,18 12,18 C13.654,18 15,19.346 15,21 C15,22.654 13.654,24 12,24" id="Combined-Shape" fill="#222222"></path>


### PR DESCRIPTION
Add  the Action Menu (optionsVertical) icon to baseIcons. The icon is exported with the name `optionsVertical`.